### PR TITLE
Update Funds.cs

### DIFF
--- a/BtceApi/Funds.cs
+++ b/BtceApi/Funds.cs
@@ -26,8 +26,8 @@ namespace BtcE
                 Nvc = o.Value<decimal>("nvc"),
                 Trc = o.Value<decimal>("trc"),
                 Ppc = o.Value<decimal>("ppc"),
-                Ftc = o.Value<decimal>("Ftc"),
-                Usd = o.Value<decimal>("Usd"),
+                Ftc = o.Value<decimal>("ftc"),
+                Usd = o.Value<decimal>("usd"),
                 Rur = o.Value<decimal>("rur"),
                 Eur = o.Value<decimal>("eur")
 			};


### PR DESCRIPTION
Not sure if it was caused by an API change or a newer version of JSON.Net, but I had to make the case for usd match the casing in the json, otherwise the value wouldn't load.
